### PR TITLE
chore: bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/cppcheck-all.yaml
+++ b/.github/workflows/cppcheck-all.yaml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
 
       - name: Upload Cppcheck report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cppcheck-report
           path: cppcheck-report.xml

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -55,7 +55,7 @@ jobs:
           cat cppcheck-report.txt
 
       - name: Upload Cppcheck report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cppcheck-report
           path: cppcheck-report.txt


### PR DESCRIPTION
v2が非推奨になったため、v4に更新。